### PR TITLE
Nav element bubbling

### DIFF
--- a/addon/components/mobile-pane/next.js
+++ b/addon/components/mobile-pane/next.js
@@ -20,10 +20,12 @@ export default Component.extend({
   }),
 
   actions: {
-    onClick(activeIndex){
+    onClick(activeIndex, evt){
+      evt.stopPropagation();
       if (get(this, 'isDisabled')) { return; }
 
       get(this, 'onClick')(activeIndex);
+      return false;
     }
   }
 });

--- a/addon/components/mobile-pane/pervious.js
+++ b/addon/components/mobile-pane/pervious.js
@@ -20,10 +20,12 @@ export default Component.extend({
   }),
 
   actions: {
-    onClick(activeIndex){
+    onClick(activeIndex, evt){
+      evt.stopPropagation();
       if (get(this, 'isDisabled')) { return; }
 
       get(this, 'onClick')(activeIndex);
+      return false;
     }
   }
 });

--- a/addon/components/mobile-pane/scroller.js
+++ b/addon/components/mobile-pane/scroller.js
@@ -6,6 +6,7 @@ import { htmlSafe } from '@ember/string';
 
 import RecognizerMixin from 'ember-mobile-core/mixins/pan-recognizer';
 import Tween from 'ember-mobile-core/tween';
+import { assert }  from '@ember/debug';
 
 export default Component.extend(RecognizerMixin, {
   layout,
@@ -32,6 +33,24 @@ export default Component.extend(RecognizerMixin, {
   dx: 0,
   dxStart: 0,
   runningAnimation: null,
+
+  // catch errors from pan-recognizer mixin; log but don't throw in production
+  didTouchMove() {
+    try {
+      this._super(...arguments)
+    } catch (error) {
+      assert(error);
+      console.error(error);
+    }
+  },
+  didTouchEnd() {
+    try {
+      this._super(...arguments)
+    } catch (error) {
+      assert(error);
+      console.error(error);
+    }
+  },
 
   onDragStart(){},
   onDragMove(dx){},

--- a/addon/templates/components/mobile-pane/next.hbs
+++ b/addon/templates/components/mobile-pane/next.hbs
@@ -1,3 +1,3 @@
-<span class="mobile-pane__next {{if isDisabled 'mobile-pane__next-disabled'}}" {{action 'onClick' activeIndex}}>
+<span class="mobile-pane__next {{if isDisabled 'mobile-pane__next-disabled'}}" onclick={{action 'onClick' activeIndex}} role="button">
   {{yield}}
 </span>

--- a/addon/templates/components/mobile-pane/pervious.hbs
+++ b/addon/templates/components/mobile-pane/pervious.hbs
@@ -1,3 +1,3 @@
-<span class="mobile-pane__previous {{if isDisabled 'mobile-pane__previous-disabled'}}" {{action 'onClick' activeIndex}}>
+<span class="mobile-pane__previous {{if isDisabled 'mobile-pane__previous-disabled'}}" onclick={{action 'onClick' activeIndex}} role="button">
   {{yield}}
 </span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mobile-pane",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
we we're getting this for free in OD cause `href-to` disables the click handler when you have `target="_blank"` set on the tag.. still not sure why it was working when you click the image directly, but it was definitely causing trouble in WB where we don't want to open a new page and fully reload. 
NOTE: I tried adding `bubbles=false` to the action helper and for some reason that didn't do the trick. I tried A LOT of things, and this was the only thing I could get to work...
